### PR TITLE
Feat ubuntu debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ With this app, the 500 EUR RTM is controlled via USB.
 
 ## Run the Project in Visual Studio Code
 
+   **On Linux**
+   You'll get the following error if your user account lacks the permissions.
+   ```
+   COM port None is not available
+   Try to connect /dev/ttyUSB0...
+   Serial connection error on port /dev/ttyUSB0: [Errno 13] Permission denied: '/dev/ttyUSB0'
+   Could not open port /dev/ttyUSB0: [Errno 13] Permission denied: '/dev/ttyUSB0'
+   COM port /dev/ttyUSB0 cannot connect
+   ```
+
+   Therefore use the following command:
+   ```
+   sudo usermod -aG dialout $USER
+   ```
+
+   IMPORTANT: Change will take effect after reboot.
 
 ### Open the Project in Visual Studio Code
 

--- a/src/config.ini
+++ b/src/config.ini
@@ -1,5 +1,5 @@
 [USB]
-port = COM15
+port = /dev/ttyUSB0
 baudrate = 460800
 
 [ADC_TO_NA]


### PR DESCRIPTION
Added Linux support (Tested on Ubuntu and Windows 11)
Main culprit was `import msvcrt` which has been replaced by `import fcntl` if Windows is not detected.

Extended documentation/README.md to handle edge cases in which Ubuntu won't connect ([Errno 13] Permission denied) to ESP32, if user does not have permission (usually the case with standard distros)
